### PR TITLE
Refactor to be more graceful.

### DIFF
--- a/qdltc.rb
+++ b/qdltc.rb
@@ -98,10 +98,7 @@ Zlib::GzipReader.open('mokuroku.csv.gz').each_line {|l|
   date = date.to_i
   url = "http://cyberjapandata.gsi.go.jp/xyz/#{THEME}/#{path}"
   zxy = path.split('.')[0]
-  mt = /\{z\}/.match(path)
-  if(mt != nil)
-  	next
-  end
+  next if /\{z\}/.match(path)
   $status[:path] = path
   if(CONTINUE && $count < CONTINUE)
     $status[:skip] += 1


### PR DESCRIPTION
コードをコンパクトにするだけの修正提案です。単にコードを完結に読みやすくするだけの意図です。

よりマニアックには、正規表現をここに使うべきかという観点はあると思いますが、その方向での検討はしていません。
### 蛇足

上記「検討はしていません」の部分の補足ですが、例えば、単に '{' を含んでいたら next にするというような考えもできますし、また、よく使う手は、

``` ruby
(z, x, y) = zxy.split('/')
next unless z.to_i.to_s == z
```

というふうに、一度数値にして文字列にしたときに元の文字列と違っていたらはねる、という手です。いずれも、今回の正規表現での実装の書き換えを提案するほどはエレガントではないので蛇足に抑えました。
