### PR TITLE
use Bundler, THEME is an option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem "sequel"
+gem "sqlite3"

--- a/qdltc.rb
+++ b/qdltc.rb
@@ -8,7 +8,7 @@ require 'thread'
 require 'time'
 require 'sequel'
 
-THEME = File.basename(File.absolute_path('.'))
+THEME = ARGV[0] || File.basename(File.absolute_path('.'))
 N_THREADS = 8
 Q_SIZE = 2000
 WAIT = 10


### PR DESCRIPTION
Gemfileを追加して、以下のようにするとSQLite3とSequelがインストールされるように変更しました。

``` shell-session
$ bundle install
$ bundle exec ruby qdltc.rb
```

また、引数を渡すと、その引数の値をTHEMEとして使うようにしています。

`bundle exec ruby qdltc.rb std`などとすると、実行しているディレクトリ名とは関係なくTHEMEの値をstdにすることができます。
